### PR TITLE
Removed Auto Capitalization from form fields

### DIFF
--- a/app/templates/gotopage.html
+++ b/app/templates/gotopage.html
@@ -10,7 +10,7 @@
       <div class="list">
         <label class="item item-input">
           <span class="input-label">Enter The Page Number</span>
-          <input type="text" ng-model="page.number">
+          <input type="number" ng-model="page.number" min = "1" max = "406">
         </label>
         <label class="item">
           <button class="button button-block button-positive" type="submit">Go</button>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -10,7 +10,7 @@
       <div class="list">
         <label class="item item-input">
           <span class="input-label">Username</span>
-          <input type="text" ng-model="loginData.username" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+          <input type="text" ng-model="loginData.username" autocomplete="off"  autocorrect="off" autocapitalize="none" spellcheck="false">
         </label>
         <label class="item item-input">
           <span class="input-label">Password</span>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -25,11 +25,11 @@
       </label>
       <label class="item item-input">
         <span class="input-label">Password</span>
-        <input type="password" ng-model="registerData.password" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
+        <input type="password" ng-model="registerData.password">
       </label>
       <label class="item item-input">
         <span class="input-label">Confirm Password</span>
-        <input type="password" ng-model="registerData.confirmPassword" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
+        <input type="password" ng-model="registerData.confirmPassword">
       </label>
       <label class="item">
         <button class="button button-block button-positive" type="submit">Register</button>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -17,19 +17,19 @@
     <div class="list">
         <label class="item item-input">
           <span class="input-label">Purchase E-mail</span>
-          <input type="text" ng-model="registerData.email">
+          <input type="text" ng-model="registerData.email" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
         </label>
       <label class="item item-input">
         <span class="input-label">New Username</span>
-        <input type="text" ng-model="registerData.username">
+        <input type="text" ng-model="registerData.username" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       </label>
       <label class="item item-input">
         <span class="input-label">Password</span>
-        <input type="password" ng-model="registerData.password">
+        <input type="password" ng-model="registerData.password" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       </label>
       <label class="item item-input">
         <span class="input-label">Confirm Password</span>
-        <input type="password" ng-model="registerData.confirmPassword">
+        <input type="password" ng-model="registerData.confirmPassword" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       </label>
       <label class="item">
         <button class="button button-block button-positive" type="submit">Register</button>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -17,19 +17,19 @@
     <div class="list">
         <label class="item item-input">
           <span class="input-label">Purchase E-mail</span>
-          <input type="text" ng-model="registerData.email" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+          <input type="text" ng-model="registerData.email" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
         </label>
       <label class="item item-input">
         <span class="input-label">New Username</span>
-        <input type="text" ng-model="registerData.username" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+        <input type="text" ng-model="registerData.username" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
       </label>
       <label class="item item-input">
         <span class="input-label">Password</span>
-        <input type="password" ng-model="registerData.password" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+        <input type="password" ng-model="registerData.password" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
       </label>
       <label class="item item-input">
         <span class="input-label">Confirm Password</span>
-        <input type="password" ng-model="registerData.confirmPassword" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+        <input type="password" ng-model="registerData.confirmPassword" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
       </label>
       <label class="item">
         <button class="button button-block button-positive" type="submit">Register</button>


### PR DESCRIPTION
I simply went through and fixed the auto capitalize function of the html input fields. While also going through and disabling other mobile things such as autocomplete and spell check etc...

In all honesty, I could not test this on my device, as I had class as I finished this, and my ionic live reload was not working (Again....) So if this could be tested for me before pulling in I would be very happy :dancer: 
